### PR TITLE
Develop

### DIFF
--- a/config/bolt/contenttypes.yaml
+++ b/config/bolt/contenttypes.yaml
@@ -15,7 +15,7 @@ courses:
       class: large
       group: content
     description:
-      type: textarea
+      type: text
       group: content
       required: true
     file:

--- a/public/theme/backend-only/backend/content-api/courses.twig
+++ b/public/theme/backend-only/backend/content-api/courses.twig
@@ -1,6 +1,7 @@
 [
 {% for course in courses %}
     {
+        "description": "{{ course.description }}",
         "filepath": "{{ absolute_url(course.filePath) }}",
         "language": "{{ course.language }}",
         "tags": {{ course.prettyTags|raw }},


### PR DESCRIPTION
Fixed a copy and paste error that was causing resourceUrl to be set to an empty string on singles.