### PR TITLE
Fixed the sorting of episodes.

### DIFF
--- a/config/bolt/contenttypes.yaml
+++ b/config/bolt/contenttypes.yaml
@@ -76,6 +76,14 @@ collections:
         yes: Yes
       default: no
       required: true
+    episodes:
+      group: content
+      type: select
+      values: episodes/{title}
+      label: Episodes
+      multiple: true
+      required: true
+      sortable: true
     slug:
       type: slug
       uses: title
@@ -85,11 +93,6 @@ collections:
       multiple: true
       order: name
       label: Select Categories
-      group: content
-    episodes:
-      multiple: true
-      order: title
-      label: Add Episodes
       group: content
   taxonomy: [ media_type, packages, tags ]
   icon_many: "fa:layer-group"
@@ -126,12 +129,6 @@ episodes:
         type: slug
         uses: title
         group: Meta
-  relations:
-    collections:
-      multiple: false
-      order: title
-      label: Collection
-      required: true
   taxonomy: [ media_type, tags ]
   icon_many: "fa:photo-video"
   icon_one: "fa:photo-video"

--- a/src/Stores/CollectionsStore.php
+++ b/src/Stores/CollectionsStore.php
@@ -136,23 +136,15 @@ class CollectionsStore extends BaseContentStore
                 $collection->addCategory($this->getTranslatedValue($relatedContent, 'name'));
             }
         }
-        $episodeRelations = $this->relationRepository->findRelations($content, 'episodes');
-        if ($episodeRelations) {
-            foreach ($episodeRelations as $related) {
-                $relatedContent = $related->getToContent();
-                if ('episodes' !== $relatedContent->getContentType()) {
-                    /**
-                     * Found a bug where getToContent() may return the collection. We need to check the from content.
-                     */
-                    $relatedContent = $related->getFromContent();
-                    if ('episodes' !== $relatedContent->getContentType()) {
-                        continue;
-                    }
-                }
-                $episode = $this->buildEpisode($relatedContent);
-                if ($episode) {
-                    $collection->addEpisode($episode);
-                }
+        /**
+         * An array of episode ids.
+         */
+        $episodes = $content->getFieldValue('episodes');
+        foreach ($episodes as $episodeId) {
+            $episodeContent = $this->contentRepository->findOneById($episodeId);
+            $episode = $this->buildEpisode($episodeContent);
+            if ($episode) {
+                $collection->addEpisode($episode);
             }
         }
 


### PR DESCRIPTION
Fixed the sorting of episodes by changing the relationship between Collections and Episodes.  This change
has side effects:

- You will need to reassign all the episodes to a given collection.  Data is not persisted from your previous install.
- You can only assign an episode to a collection from the collection form.

Please merge into main when approved.